### PR TITLE
Allows users to edit influence boxes when in Estimate/Scoring mode.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -319,6 +319,13 @@ class App extends Component {
         state.mode === 'estimator'
           ? influence.map(scoreBoard.signMap, {discrete: true})
           : influence.areaMap(scoreBoard.signMap)
+
+      for (let vertex in state.estimateOverrides) {
+        let clickCount = state.estimateOverrides[vertex]
+        let coord = vertex.split('x')
+        let val = areaMap[coord[0]][coord[1]] + 1 + clickCount
+        areaMap[coord[0]][coord[1]] = (val % 3) - 1
+      }
     }
 
     state = {...state, ...inferredState, scoreBoard, areaMap}

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -53,6 +53,7 @@ class Sabaki extends EventEmitter {
       findVertex: null,
       deadStones: [],
       blockedGuesses: [],
+      estimateOverrides: {},
 
       // Goban
 
@@ -243,6 +244,8 @@ class Sabaki extends EventEmitter {
 
   setMode(mode) {
     if (this.state.mode === mode) return
+
+    this.setState({estimateOverrides: {}})
 
     let stateChange = {mode}
 
@@ -960,7 +963,19 @@ class Sabaki extends EventEmitter {
         this.editVertexData = null
       }
     } else if (['scoring', 'estimator'].includes(this.state.mode)) {
-      if (button !== 0 || board.get(vertex) === 0) return
+      if (button !== 0) return
+
+      if (board.get(vertex) === 0) {
+        let {estimateOverrides} = this.state
+
+        let clickCount = estimateOverrides[vertex[1] + 'x' + vertex[0]]
+        clickCount = !clickCount ? 1 : clickCount + 1
+
+        estimateOverrides[vertex[1] + 'x' + vertex[0]] = clickCount
+
+        this.setState({estimateOverrides})
+        return
+      }
 
       let {mode, deadStones} = this.state
       let dead = deadStones.some(v => helper.vertexEquals(v, vertex))


### PR DESCRIPTION
When in scoring or estimation mode, we now track any vertexes that the user clicks via the state.estimateOverrides property.  In our app render method, we then override the area influence map with these clicks.  Clicks cycle through black/white/ empty.  A +1, -1 is used in the equations to reflect the fact that black/white/empty values in the influence map are tracked via values of [-1,0,1].